### PR TITLE
Merge beta into master

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -61,7 +61,7 @@ jobs:
       - id: configure-compilation-target-matrix
         run: |
           : configure compilation target matrix
-          matrix="$(jq \
+          matrix="$(jq --compact-output \
             --argjson whitelist "$(echo "$whitelist" | jq --raw-input --compact-output --slurp '[splits("[ \n]+")] | map(select(length > 0))')" \
             'map(select(.target | IN($whitelist[])))' \
             <<< "$all_compilation_targets")"

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -4,12 +4,24 @@ name: Release Binary
 on:
   workflow_call:
     inputs:
+      targets:
+        description: Whitelist of compilation targets to upload GitHub release binaries for. Must be a subset of supported targets.
+        type: string
+        default: |
+          aarch64-apple-darwin
+          aarch64-unknown-linux-gnu
+          aarch64-unknown-linux-musl
+          i686-unknown-linux-gnu
+          i686-unknown-linux-musl
+          x86_64-apple-darwin
+          x86_64-unknown-linux-gnu
+          x86_64-unknown-linux-musl
       test-command:
         description: Command used to test your Rust program
         type: string
         default: cargo test
       toolchain:
-        description: Rust toolchain specification -- see https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification
+        description: Rust toolchain specification
         type: string
         default: stable
       disable-semantic-release-cargo:
@@ -36,6 +48,68 @@ env:
 jobs:
   get-next-version:
     uses: semantic-release-action/next-release-version/.github/workflows/next-release-version.yml@v2
+
+  configure-compilation-target-matrix:
+    name: Configure compilation targets
+    runs-on: ubuntu-latest
+    needs:
+      - get-next-version
+    outputs:
+      matrix: ${{ steps.configure-compilation-target-matrix.outputs.matrix }}
+
+    steps:
+      - id: configure-compilation-target-matrix
+        run: |
+          : configure compilation target matrix
+          matrix="$(jq \
+            --argjson whitelist "$(echo "$supported" | jq --raw-input --compact-output --slurp '[splits("[ \n]+")] | map(select(length > 0))')" \
+            'map(select(.target | IN($whitelist[])))' \
+            <<< "$all_compilation_targets")"
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+        env:
+          all_compilation_targets: |
+            [
+              {
+                "target": "aarch64-apple-darwin",
+                "host": "macOS-latest",
+                "cross": true
+              },
+              {
+                "target": "aarch64-unknown-linux-gnu",
+                "host": "ubuntu-latest",
+                "cross": true
+              },
+              {
+                "target": "aarch64-unknown-linux-musl",
+                "host": "ubuntu-latest",
+                "cross": true
+              },
+              {
+                "target": "i686-unknown-linux-gnu",
+                "host": "ubuntu-latest",
+                "cross": true
+              },
+              {
+                "target": "i686-unknown-linux-musl",
+                "host": "ubuntu-latest",
+                "cross": true
+              },
+              {
+                "target": "x86_64-apple-darwin",
+                "host": "macOS-latest",
+                "cross": false
+              },
+              {
+                "target": "x86_64-unknown-linux-gnu",
+                "host": "ubuntu-latest",
+                "cross": false
+              },
+              {
+                "target": "x86_64-unknown-linux-musl",
+                "host": "ubuntu-latest",
+                "cross": false
+              }
+            ]
 
   test:
     name: Cargo test
@@ -69,9 +143,10 @@ jobs:
   build-release:
     name: Build CLI ${{ matrix.build.target }}
     if: needs.get-next-version.outputs.new-release-published == 'true'
-    runs-on: ${{ matrix.build.os }}
+    runs-on: ${{ matrix.build.host }}
     needs:
       - get-next-version
+      - configure-compilation-target-matrix
     outputs:
       binary-name: ${{ steps.get-binary-name.outputs.binary-name }}
     env:
@@ -80,32 +155,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build:
-          # alphabatized by target
-          - os: macOS-latest
-            target: aarch64-apple-darwin
-            cross: true
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            cross: true
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-musl
-            cross: true
-          - os: ubuntu-latest
-            target: i686-unknown-linux-gnu
-            cross: true
-          - os: ubuntu-latest
-            target: i686-unknown-linux-musl
-            cross: true
-          - os: macOS-latest
-            target: x86_64-apple-darwin
-            cross: false
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            cross: false
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            cross: false
+        build: ${{ fromJson(needs.configure-compilation-target-matrix.outputs.matrix) }}
 
     steps:
       - name: Checkout
@@ -196,3 +246,4 @@ jobs:
           disable-semantic-release-cargo: ${{ inputs.disable-semantic-release-cargo }}
           disable-semantic-release-git: ${{ inputs.disable-semantic-release-git }}
           next-version: ${{ needs.get-next-version.outputs.new-release-version }}
+          targets: ${{ inputs.targets }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -62,13 +62,12 @@ jobs:
         run: |
           : configure compilation target matrix
           matrix="$(jq \
-            --argjson whitelist "$(echo "$supported" | jq --raw-input --compact-output --slurp '[splits("[ \n]+")] | map(select(length > 0))')" \
+            --argjson whitelist "$(echo "$whitelist" | jq --raw-input --compact-output --slurp '[splits("[ \n]+")] | map(select(length > 0))')" \
             'map(select(.target | IN($whitelist[])))' \
             <<< "$all_compilation_targets")"
-          echo "Using comilation matrix:"
-          echo "$matrix"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
         env:
+          whitelist: ${{ inputs.targets }}
           all_compilation_targets: |
             [
               {

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -51,6 +51,7 @@ jobs:
 
   configure-compilation-target-matrix:
     name: Configure compilation targets
+    if: needs.get-next-version.outputs.new-release-published == 'true'
     runs-on: ubuntu-latest
     needs:
       - get-next-version

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -65,7 +65,9 @@ jobs:
             --argjson whitelist "$(echo "$supported" | jq --raw-input --compact-output --slurp '[splits("[ \n]+")] | map(select(length > 0))')" \
             'map(select(.target | IN($whitelist[])))' \
             <<< "$all_compilation_targets")"
-          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          echo "Using comilation matrix:"
+          echo "$matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
         env:
           all_compilation_targets: |
             [

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -9,7 +9,7 @@ on:
         type: string
         default: cargo test
       toolchain:
-        description: Rust toolchain specification -- see https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification
+        description: Rust toolchain specification
         type: string
         default: stable
       disable-semantic-release-git:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [4.1.0-beta.2](https://github.com/semantic-release-action/rust/compare/v4.1.0-beta.1...v4.1.0-beta.2) (2023-02-05)
+
+
+### Bug Fixes
+
+* add debug logs ([eda9b91](https://github.com/semantic-release-action/rust/commit/eda9b919026b88ea7685d4265d26ea47da0bdd43))
+
 # [4.1.0-beta.1](https://github.com/semantic-release-action/rust/compare/v4.0.14...v4.1.0-beta.1) (2023-02-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [4.1.0-beta.4](https://github.com/semantic-release-action/rust/compare/v4.1.0-beta.3...v4.1.0-beta.4) (2023-02-05)
+
+
+### Bug Fixes
+
+* use single line string in step output ([ee65603](https://github.com/semantic-release-action/rust/commit/ee6560395c59b22aa8153147bf2b67d11e519644))
+
 # [4.1.0-beta.3](https://github.com/semantic-release-action/rust/compare/v4.1.0-beta.2...v4.1.0-beta.3) (2023-02-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [4.1.0-beta.3](https://github.com/semantic-release-action/rust/compare/v4.1.0-beta.2...v4.1.0-beta.3) (2023-02-05)
+
+
+### Bug Fixes
+
+* use correct variable name ([c1d8895](https://github.com/semantic-release-action/rust/commit/c1d889505c8fdb541cf3553d2403382fed9ddc45))
+
 # [4.1.0-beta.2](https://github.com/semantic-release-action/rust/compare/v4.1.0-beta.1...v4.1.0-beta.2) (2023-02-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [4.1.0-beta.1](https://github.com/semantic-release-action/rust/compare/v4.0.14...v4.1.0-beta.1) (2023-02-05)
+
+
+### Features
+
+* **release-binary:** support whitelist of compilation targets ([fb84a2f](https://github.com/semantic-release-action/rust/commit/fb84a2fa1d05fbf663cb5266f90eddd9427f110f)), closes [#15](https://github.com/semantic-release-action/rust/issues/15)
+
 ## [4.0.14](https://github.com/semantic-release-action/rust/compare/v4.0.13...v4.0.14) (2023-02-04)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [4.1.0-beta.5](https://github.com/semantic-release-action/rust/compare/v4.1.0-beta.4...v4.1.0-beta.5) (2023-02-05)
+
+
+### Bug Fixes
+
+* skip matrix configuration when possible ([19455f2](https://github.com/semantic-release-action/rust/commit/19455f2cb6e6ee15b183604b9f36255ba6be5667))
+
 # [4.1.0-beta.4](https://github.com/semantic-release-action/rust/compare/v4.1.0-beta.3...v4.1.0-beta.4) (2023-02-05)
 
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ jobs:
 
 | Input Parameter |   Default    | Description                                                                            |
 | :-------------: | :----------: | -------------------------------------------------------------------------------------- |
-|    toolchain    |   `stable`   | Rust toolchain specification. [Details](#toolchain)                                    |
 |  test-command   | `cargo test` | Shell command used to provide confidence in proposed changes. [Details](#test-command) |
+|    toolchain    |   `stable`   | Rust toolchain specification. [Details](#toolchain)                                    |
 
 #### toolchain
 
@@ -109,12 +109,41 @@ jobs:
 
 ### Inputs
 
-|        Input Parameter         |   Default    | Description                                                                                       |
-| :----------------------------: | :----------: | ------------------------------------------------------------------------------------------------- |
-|           toolchain            |   `stable`   | Rust toolchain specification. [Details](#toolchain)                                               |
-|          test-command          | `cargo test` | Shell command used to provide confidence in proposed changes. [Details](#test-command)            |
-| disable-semantic-release-cargo |   `false`    | Disable [semantic-release-cargo] in your release flow. [Details](#disable-semantic-release-cargo) |
-|  disable-semantic-release-git  |   `false`    | Disable [@semantic-release/git] in your release flow. [Details](#disable-semantic-release-git)    |
+|        Input Parameter         |    Default    | Description                                                                                       |
+| :----------------------------: | :-----------: | ------------------------------------------------------------------------------------------------- |
+|            targets             | all supported | Whitelist of compilation targets to upload GitHub release binaries for. [Details](#targets)       |
+|          test-command          | `cargo test`  | Shell command used to provide confidence in proposed changes. [Details](#test-command)            |
+|           toolchain            |   `stable`    | Rust toolchain specification. [Details](#toolchain)                                               |
+| disable-semantic-release-cargo |    `false`    | Disable [semantic-release-cargo] in your release flow. [Details](#disable-semantic-release-cargo) |
+|  disable-semantic-release-git  |    `false`    | Disable [@semantic-release/git] in your release flow. [Details](#disable-semantic-release-git)    |
+
+#### targets
+
+Whitelist of compilation targets to upload GitHub release binaries for. Must be a subset of supported targets:
+
+- aarch64-apple-darwin
+- aarch64-unknown-linux-gnu
+- aarch64-unknown-linux-musl
+- i686-unknown-linux-gnu
+- i686-unknown-linux-musl
+- x86_64-apple-darwin
+- x86_64-unknown-linux-gnu
+- x86_64-unknown-linux-musl
+
+Separate each target with whitespace:
+
+```yaml
+jobs:
+  release:
+    uses: semantic-release-action/rust/.github/workflows/release-binary.yml@v4
+    with:
+      targets: |
+        aarch64-apple-darwin
+        x86_64-apple-darwin
+        x86_64-unknown-linux-musl
+    secrets:
+      cargo-registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+```
 
 #### disable-semantic-release-cargo
 

--- a/semantic-release-binary/action.yml
+++ b/semantic-release-binary/action.yml
@@ -10,25 +10,24 @@ branding:
 # (which is only supported in composite actions)
 
 inputs:
+  targets:
+    description: Whitelist of compilation targets to upload GitHub release binaries for. Must be a subset of supported targets.
+    required: true
   toolchain:
-    description: Rust toolchain specification -- see https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification
+    description: Rust toolchain specification
     required: false
-    type: string
     default: stable
   binary-name:
     description: The name of your Rust binary
     required: true
-    type: string
   cargo-registry-token:
     description: API token for writing to your cargo registry
     required: true
   disable-semantic-release-cargo:
     description: Disable semantic-release-cargo in your release flow. Only takes effect if the action semantic-release config is used.
-    type: boolean # This is ignored, you're really passing a string
     default: false
   disable-semantic-release-git:
     description: Disable @semantic-release/git in your release flow. Only takes effect if the action semantic-release config is used.
-    type: boolean # This is ignored, you're really passing a string
     default: false
   next-version:
     description: Next semantic-release version number
@@ -64,7 +63,9 @@ runs:
     - name: Install is-semantic-release-configured
       uses: EricCrosson/install-github-release-binary@v2
       with:
-        targets: EricCrosson/is-semantic-release-configured@v1
+        targets: |
+          EricCrosson/is-semantic-release-configured@v1
+          EricCrosson/configure-semantic-release-assets@v1
 
     # Terminology:
     #
@@ -136,6 +137,11 @@ runs:
       run: |
         : disable @semantic-release/git
         configure-semantic-release-manifest --in-place --remove @semantic-release/git
+      shell: bash
+
+    - run: |
+        : configure semantic-release assets
+        configure-semantic-release-assets --in-place whitelist "${{ inputs.targets }} SHA256SUMS.txt"
       shell: bash
 
     # If the semantic-release-cargo plugin never runs, the cargo manifest never has its version bumped.

--- a/semantic-release-library/action.yml
+++ b/semantic-release-library/action.yml
@@ -11,18 +11,15 @@ branding:
 
 inputs:
   toolchain:
-    description: Rust toolchain specification -- see https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification
+    description: Rust toolchain specification
     required: false
-    type: string
     default: stable
   test-command:
     description: Command used to test your Rust program
     required: false
-    type: string
     default: cargo test
   disable-semantic-release-git:
     description: Disable @semantic-release/git in your release flow. Only takes effect if the action semantic-release config is used.
-    type: boolean # This is ignored, you're really passing a string
     default: false
   cargo-registry-token:
     description: API token for writing to your cargo registry


### PR DESCRIPTION
Closes https://github.com/semantic-release-action/rust/issues/15

The release-binary workflow now supports compiling only a subset of
the supported compilation targets:

```yaml
jobs:
  release:
    uses: semantic-release-action/rust/.github/workflows/release-binary.yml@v4
    with:
      targets: |
        aarch64-apple-darwin
        x86_64-apple-darwin
        x86_64-unknown-linux-musl
    secrets:
      cargo-registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
```

See more details in the readme.