### PR TITLE
Support releasing multiple binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,6 @@ on:
         required: false
         type: string
         default: stable
-      test-command:
-        description: Cargo command used to provide confidence in proposed changes
-        required: false
-        type: string
-        default: cargo test --locked -- --nocapture
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -54,10 +49,12 @@ jobs:
           )"
           echo "is-crate-library=$is_crate_library" >> "$GITHUB_OUTPUT"
 
+      # REFACTOR: can use the cargo manifest command to check if this is a library crate,
+      # or just check if there is a Cargo.lock file
       - name: Construct test command
         id: format-test-command
         env:
-          input_test_command: ${{ inputs.test-command }}
+          input_test_command: cargo test --locked -- --nocapture
           is_crate_library: ${{ steps.check-if-crate-is-library.outputs.is-crate-library }}
         run: |
           test_command="$input_test_command"
@@ -71,7 +68,6 @@ jobs:
           echo "test-command=$test_command" >> "$GITHUB_OUTPUT"
 
       # Separate compilation from testing to accurately report the runtime of each
-      - if: startsWith(steps.format-test-command.outputs.test-command, 'cargo test')
-        run: cargo test ${{ contains(steps.format-test-command.outputs.test-command, '--locked') && '--locked' || '' }} --no-run
+      - run: cargo test ${{ contains(steps.format-test-command.outputs.test-command, '--locked') && '--locked' || '' }} --no-run
 
-      - run: ${{ inputs.test-command }}
+      - run: ${{ steps.format-test-command.outputs.test-command }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -136,7 +136,7 @@ jobs:
               --argjson targets_whitelist "$targets_whitelist" \
               --argjson target_triples "$target_triples" \
               --argjson binary_names "$binary_names" \
-              '($target_triples[] | select(.target | IN($targets_whitelist[]))) + $binary_names[]'
+              '[$target_triples[] | select(.target | IN($targets_whitelist[])) + $binary_names[]]'
           )"
           {
             echo "matrix<<EOF"

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -111,7 +111,7 @@ jobs:
           has_name_collisions="$(jq 'length > 0' <<< "$name_collisions")"
 
           if [[ $has_name_collisions == true ]]; then
-            targets="$(jq 'join(", ")' <<< "$name_collisions")"
+            targets="$(jq --raw-output 'join(", ")' <<< "$name_collisions")"
             echo "::error title={Binary name collision detected}::Refusing to process binary targets \"$targets\" due to name collisions"
             exit 1
           fi

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -75,7 +75,7 @@ jobs:
               --null-input \
               --raw-input \
               '[inputs] | map(splits("\\s+") | select(length > 0))' \
-              "$raw_targets"
+              <<< "$raw_targets"
           )"
 
           # Array<string>

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -22,10 +22,6 @@ on:
           x86_64-apple-darwin
           x86_64-unknown-linux-gnu
           x86_64-unknown-linux-musl
-      test-command:
-        description: Command used to test your Rust program
-        type: string
-        default: cargo test --locked -- --nocapture
       toolchain:
         description: Rust toolchain specification
         type: string
@@ -251,19 +247,20 @@ jobs:
 
       # Separate compilation from testing to accurately report the runtime of each
 
-      # DISCUSS: is it possible to simplify the complexity here? Maybe we can assume the
-      # dependencies need to be installed to run tests, even if `cargo test` isn't how the tests are invoked.
-      # Consider that change for a future release.
-      - if: startsWith(inputs.test-command, 'cargo test')
-        run: |
+      - run: |
+          : build tests
           cargo test \
             --target ${{ matrix.test.target }} \
             --no-run \
-            ${{ contains(inputs.test-command, '--locked') && '--locked' || '' }}
+            --locked
 
       - run: |
-          ${{ inputs.test-command }} \
-            --target ${{ matrix.test.target }}
+          : tests
+          cargo test \
+            --target ${{ matrix.test.target }} \
+            --locked \
+            -- \
+            --nocapture
 
   # Compile release artifacts
   build-release:

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -64,6 +64,9 @@ jobs:
       matrix: ${{ steps.configure-compilation-matrix.outputs.matrix }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - id: sanitize-input-targets
         env:
           raw_targets: ${{ inputs.targets }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -192,7 +192,7 @@ jobs:
 
   # Compile release artifacts
   build-release:
-    name: Build ${{ matrix.build.binary_name }} ${{ matrix.build.target }}
+    name: (${{ matrix.build.binary_name }}, ${{ matrix.build.target }})
     if: needs.get-next-version.outputs.new-release-published == 'true'
     runs-on: ${{ matrix.build.host }}
     needs:
@@ -313,9 +313,10 @@ jobs:
       - name: Release
         uses: semantic-release-action/rust/semantic-release-binary@v4
         with:
+          toolchain: ${{ inputs.toolchain }}
+          compiled-targets: ${{ needs.configure-compilation-matrix.outputs.matrix }}
           cargo-registry-token: ${{ secrets.cargo-registry-token }}
           disable-semantic-release-cargo: ${{ inputs.disable-semantic-release-cargo }}
           disable-semantic-release-git: ${{ inputs.disable-semantic-release-git }}
           next-version: ${{ needs.get-next-version.outputs.new-release-version }}
           submodules: ${{ inputs.submodules }}
-          compiled-targets: ${{ needs.configure-compilation-matrix.outputs.matrix }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -311,7 +311,7 @@ jobs:
 
     steps:
       - name: Release
-        uses: semantic-release-action/rust/semantic-release-binary@v4
+        uses: semantic-release-action/rust/semantic-release-binary@beta
         with:
           toolchain: ${{ inputs.toolchain }}
           compiled-targets: ${{ needs.configure-compilation-matrix.outputs.matrix }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -138,12 +138,13 @@ jobs:
               '[$target_triples[] | select(.target | IN($targets_whitelist[])) + $binary_names[]]'
           )"
 
+          # TODO: support running tests on aarch64-apple-darwin. Cross was complaining
           test_matrix="$(
             jq \
               --null-input \
               --argjson targets_whitelist "$targets_whitelist" \
               --argjson target_triples "$target_triples" \
-              '[$target_triples[] | select(.target | IN($targets_whitelist[]))]'
+              '[$target_triples[] | select((.target | IN($targets_whitelist[])) and (.target != "aarch64-apple-darwin"))]'
           )"
 
           {

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -1,6 +1,7 @@
 ---
 name: Release Binary
 
+# DISCUSS: adding a whitelist for binaries to publish
 on:
   workflow_call:
     inputs:
@@ -53,24 +54,86 @@ jobs:
   get-next-version:
     uses: semantic-release-action/next-release-version/.github/workflows/next-release-version.yml@v4
 
-  configure-compilation-target-matrix:
+  configure-compilation-matrix:
     name: Configure compilation targets
     if: needs.get-next-version.outputs.new-release-published == 'true'
     runs-on: ubuntu-latest
     needs:
       - get-next-version
     outputs:
-      matrix: ${{ steps.configure-compilation-target-matrix.outputs.matrix }}
+      matrix: ${{ steps.configure-compilation-matrix.outputs.matrix }}
 
     steps:
-      - id: configure-compilation-target-matrix
+      - id: sanitize-input-targets
+        env:
+          raw_targets: ${{ inputs.targets }}
         run: |
-          : configure compilation target matrix
+          : sanitize targets input
+
+          targets="$(
+            jq \
+              --null-input \
+              --raw-input \
+              '[inputs] | map(splits("\\s+") | select(length > 0))' \
+              "$raw_targets"
+          )"
+
+          # Array<string>
+          {
+            echo "targets<<EOF"
+            echo "$targets"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - id: get-binary-names
+        run: |
+          : detect binary names
+
+          # Array<{ binary_name: string, src_path: string }>
+          binary_manifest="$(
+            cargo metadata --no-deps --format-version 1 \
+              | jq '.packages | map(.targets[] | select(.kind[] | IN("bin")) | { binary_name, src_path })'
+          )"
+
+          # Validate there are no binary-name collisions
+          # https://github.com/rust-lang/cargo/issues/6313
+
+          # Array<string>
+          name_collisions="$(
+            jq \
+              'group_by(.binary_name) | map(select(length > 1)[] | .binary_name) | unique' \
+              <<< "$binary_manifest"
+          )"
+
+          has_name_collisions="$(jq 'length > 0' <<< "$name_collisions")"
+
+          if [[ $has_name_collisions == true ]]; then
+            targets="$(jq 'join(", ")' <<< "$name_collisions")"
+            echo "::error title={Binary name collision detected}::Refusing to process binary targets \"$targets\" due to name collisions"
+            exit 1
+          fi
+
+          binary_names="$(jq 'map({ binary_name })' <<< "$binary_manifest")"
+
+          # Array<{ binary_name: string }>
+          {
+            echo "binary-names<<EOF"
+            echo "$binary_names"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - id: configure-compilation-matrix
+        run: |
+          : configure compilation matrix
+
+          # Perform a cartesian product of target_triples and binary_names
           matrix="$(
             jq \
-              --argjson whitelist "$(echo "$whitelist" | jq --raw-input --slurp '[splits("[ \n]+")] | map(select(length > 0))')" \
-              'map(select(.target | IN($whitelist[])))' \
-              <<< "$all_compilation_targets"
+              --null-input \
+              --argjson targets_whitelist "$targets_whitelist" \
+              --argjson target_triples "$target_triples" \
+              --argjson binary_names "$binary_names" \
+              '($target_triples[] | select(.target | IN($targets_whitelist))) + $binary_name[]'
           )"
           {
             echo "matrix<<EOF"
@@ -78,8 +141,9 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
         env:
-          whitelist: ${{ inputs.targets }}
-          all_compilation_targets: |
+          targets_whitelist: ${{ steps.sanitize-input-targets.outputs.targets }}
+          binary_names: ${{ steps.get-binary-names.outputs.binary-names }}
+          target_triples: |
             [
               {
                 "target": "aarch64-apple-darwin",
@@ -123,46 +187,24 @@ jobs:
               }
             ]
 
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: ${{ inputs.submodules }}
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ inputs.toolchain }}
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-
-      # Separate compilation from testing to accurately report the runtime of each
-      - if: startsWith(inputs.test-command, 'cargo test')
-        run: cargo test ${{ contains(inputs.test-command, '--locked') && '--locked' || '' }} --no-run
-
-      - run: ${{ inputs.test-command }}
-
   # Compile release artifacts
   build-release:
-    name: Build CLI ${{ matrix.build.target }}
+    name: Build ${{ matrix.build.binary_name }} ${{ matrix.build.target }}
     if: needs.get-next-version.outputs.new-release-published == 'true'
     runs-on: ${{ matrix.build.host }}
     needs:
       - get-next-version
-      - configure-compilation-target-matrix
-    outputs:
-      binary-name: ${{ steps.get-binary-name.outputs.binary-name }}
+      - configure-compilation-matrix
 
     strategy:
       fail-fast: false
       matrix:
-        build: ${{ fromJson(needs.configure-compilation-target-matrix.outputs.matrix) }}
+        build: ${{ fromJson(needs.configure-compilation-matrix.outputs.matrix) }}
 
     steps:
+      ###
+      # Phase 1: set up
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -178,44 +220,71 @@ jobs:
           toolchain: ${{ inputs.toolchain }}
           target: ${{ matrix.build.target }}
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install semantic-release-cargo
-        uses: EricCrosson/install-github-release-binary@v2
-        with:
-          targets: semantic-release-cargo/semantic-release-cargo@v2
-
-      - name: Prepare semantic-release for Rust
-        run: semantic-release-cargo --verbose --verbose --verbose prepare ${{ needs.get-next-version.outputs.new-release-version }}
-
-      - name: Detect binary name
-        id: get-binary-name
-        run: |
-          binary_names="$(
-            cargo metadata --no-deps --format-version 1 \
-              | jq --raw-output '.packages[0].targets | map(select(.kind[] | contains("bin")).name)[0]'
-          )"
-          echo "binary-name=$binary_names" >> "$GITHUB_OUTPUT"
-
       - name: Install cross
         uses: taiki-e/install-action@v2
         if: matrix.build.cross
         with:
           tool: cross
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      ###
+      # Phase 2: test
+
+      # Separate compilation from testing to accurately report the runtime of each
+
+      # DISCUSS: is it possible to simplify the complexity here? Maybe we can assume the
+      # dependencies need to be installed to run tests, even if `cargo test` isn't how the tests are invoked.
+      # Consider that change for a future release.
+      - if: startsWith(inputs.test-command, 'cargo test')
+        run: cargo test --no-run ${{ contains(inputs.test-command, '--locked') && '--locked' || '' }}
+
+      - run: ${{ inputs.test-command }}
+
+      ###
+      # Phase 3: compile release binary
+
       - name: Compile release binary
         env:
           CARGO: ${{ matrix.build.cross && 'cross' || 'cargo' }}
-        run: ${{ env.CARGO }} build --release --target ${{ matrix.build.target }} --verbose
+        run: |
+          ${{ env.CARGO }} build \
+            --verbose \
+            --release \
+            --bin ${{ matrix.build.binary_name }} \
+            --target ${{ matrix.build.target }}
+
+      ###
+      # Phase 4: configure release artifacts
+
+      - name: Install semantic-release-cargo
+        uses: EricCrosson/install-github-release-binary@v2
+        with:
+          targets: semantic-release-cargo/semantic-release-cargo@v2
+
+      # NOTE: semantic-release-cargo currently implements the "lock-step"
+      # versioning strategy, where all crates in a workspace are bumped to the
+      # next version simultaneously.
+      - name: Prepare semantic-release for Rust
+        run: |
+          semantic-release-cargo \
+            --verbose --verbose --verbose \
+            prepare ${{ needs.get-next-version.outputs.new-release-version }}
 
       - name: Create release artifacts
         run: |
           mkdir dist
-          cp target/${{ matrix.build.target }}/release/${{ steps.get-binary-name.outputs.binary-name }} dist/${{ steps.get-binary-name.outputs.binary-name }}-${{ matrix.build.target }}
+          cp \
+            target/${{ matrix.build.target }}/release/${{ matrix.build.binary_name }} \
+            dist/${{ matrix.build.binary_name }}-${{ matrix.build.target }}
 
       - name: Create binary checksum
-        run: shasum --algorithm 256 --binary ${{ steps.get-binary-name.outputs.binary-name }}-${{ matrix.build.target }} | tee ${{ steps.get-binary-name.outputs.binary-name }}-${{ matrix.build.target }}-SHA256SUM.txt
+        run: |
+          shasum \
+            --algorithm 256 \
+            --binary ${{ matrix.build.binary_name }}-${{ matrix.build.target }} \
+            | tee ${{ matrix.build.binary_name }}-${{ matrix.build.target }}-SHA256SUM.txt
         working-directory: ./dist
 
       - name: Upload release artifacts
@@ -223,8 +292,8 @@ jobs:
         with:
           name: ${{ matrix.build.target }}
           path: |
-            dist/${{ steps.get-binary-name.outputs.binary-name }}-${{ matrix.build.target }}
-            dist/${{ steps.get-binary-name.outputs.binary-name }}-${{ matrix.build.target }}-SHA256SUM.txt
+            dist/${{ matrix.build.binary_name }}-${{ matrix.build.target }}
+            dist/${{ matrix.build.binary_name }}-${{ matrix.build.target }}-SHA256SUM.txt
           if-no-files-found: error
           retention-days: 1
 
@@ -233,18 +302,17 @@ jobs:
     if: needs.get-next-version.outputs.new-release-published == 'true'
     runs-on: ubuntu-latest
     needs:
-      - build-release
       - get-next-version
-      - test
+      - configure-compilation-matrix
+      - build-release
 
     steps:
       - name: Release
         uses: semantic-release-action/rust/semantic-release-binary@v4
         with:
-          binary-name: ${{ needs.build-release.outputs.binary-name }}
           cargo-registry-token: ${{ secrets.cargo-registry-token }}
           disable-semantic-release-cargo: ${{ inputs.disable-semantic-release-cargo }}
           disable-semantic-release-git: ${{ inputs.disable-semantic-release-git }}
           next-version: ${{ needs.get-next-version.outputs.new-release-version }}
           submodules: ${{ inputs.submodules }}
-          targets: ${{ inputs.targets }}
+          compiled-targets: ${{ needs.configure-compilation-matrix.outputs.matrix }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -95,7 +95,7 @@ jobs:
           # Array<{ binary_name: string, src_path: string }>
           binary_manifest="$(
             cargo metadata --no-deps --format-version 1 \
-              | jq '.packages | map(.targets[] | select(.kind[] | IN("bin")) | { binary_name, src_path })'
+              | jq '.packages | map(.targets[] | select(.kind[] | IN("bin")) | { binary_name: .name, src_path })'
           )"
 
           # Validate there are no binary-name collisions

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -54,14 +54,15 @@ jobs:
   get-next-version:
     uses: semantic-release-action/next-release-version/.github/workflows/next-release-version.yml@v4
 
-  configure-compilation-matrix:
+  configure-job-matrix:
     name: Configure compilation targets
     if: needs.get-next-version.outputs.new-release-published == 'true'
     runs-on: ubuntu-latest
     needs:
       - get-next-version
     outputs:
-      matrix: ${{ steps.configure-compilation-matrix.outputs.matrix }}
+      compilation-matrix: ${{ steps.configure-job-matrix.outputs.compilation-matrix }}
+      test-matrix: ${{ steps.configure-job-matrix.outputs.test-matrix }}
 
     steps:
       - name: Checkout
@@ -80,6 +81,8 @@ jobs:
               '[inputs] | map(splits("\\s+") | select(length > 0))' \
               <<< "$raw_targets"
           )"
+
+          # TODO: enforce that every target is in the whitelist of targets
 
           # Array<string>
           {
@@ -125,12 +128,12 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - id: configure-compilation-matrix
+      - id: configure-job-matrix
         run: |
           : configure compilation matrix
 
           # Perform a cartesian product of target_triples and binary_names
-          matrix="$(
+          compilation_matrix="$(
             jq \
               --null-input \
               --argjson targets_whitelist "$targets_whitelist" \
@@ -138,9 +141,22 @@ jobs:
               --argjson binary_names "$binary_names" \
               '[$target_triples[] | select(.target | IN($targets_whitelist[])) + $binary_names[]]'
           )"
+
+          test_matrix="$(
+            jq \
+              --null-input \
+              --argjson targets_whitelist "$targets_whitelist" \
+              --argjson target_triples "$target_triples" \
+              '[$target_triples[] | select(.target | IN($targets_whitelist[]))]'
+          )"
+
           {
-            echo "matrix<<EOF"
-            echo "$matrix"
+            echo "compilation-matrix<<EOF"
+            echo "$compilation_matrix"
+            echo "EOF"
+
+            echo "test-matrix<<EOF"
+            echo "$test_matrix"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
         env:
@@ -190,6 +206,65 @@ jobs:
               }
             ]
 
+  test:
+    name: Test ${{ matrix.test.target }}
+    runs-on: ${{ matrix.test.host }}
+    needs:
+      - get-next-version
+      - configure-job-matrix
+
+    strategy:
+      fail-fast: false
+      matrix:
+        test: ${{ fromJson(needs.configure-job-matrix.outputs.test-matrix) }}
+
+    steps:
+      ###
+      # Phase 1: set up
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: ${{ inputs.submodules }}
+
+      - name: Install build inputs
+        if: runner.os == 'Linux' && !matrix.test.cross && endsWith(matrix.test.target, '-musl')
+        run: sudo apt install musl-tools
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ inputs.toolchain }}
+          target: ${{ matrix.test.target }}
+
+      - name: Install cross
+        uses: taiki-e/install-action@v2
+        if: matrix.test.cross
+        with:
+          tool: cross
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      ###
+      # Phase 2: test
+
+      # Separate compilation from testing to accurately report the runtime of each
+
+      # DISCUSS: is it possible to simplify the complexity here? Maybe we can assume the
+      # dependencies need to be installed to run tests, even if `cargo test` isn't how the tests are invoked.
+      # Consider that change for a future release.
+      - if: startsWith(inputs.test-command, 'cargo test')
+        run: |
+          cargo test \
+            --target ${{ matrix.test.target }} \
+            --no-run \
+            ${{ contains(inputs.test-command, '--locked') && '--locked' || '' }}
+
+      - run: |
+          ${{ inputs.test-command }} \
+            --target ${{ matrix.test.target }}
+
   # Compile release artifacts
   build-release:
     name: (${{ matrix.build.binary_name }}, ${{ matrix.build.target }})
@@ -197,12 +272,12 @@ jobs:
     runs-on: ${{ matrix.build.host }}
     needs:
       - get-next-version
-      - configure-compilation-matrix
+      - configure-job-matrix
 
     strategy:
       fail-fast: false
       matrix:
-        build: ${{ fromJson(needs.configure-compilation-matrix.outputs.matrix) }}
+        build: ${{ fromJson(needs.configure-job-matrix.outputs.compilation-matrix) }}
 
     steps:
       ###
@@ -233,20 +308,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       ###
-      # Phase 2: test
-
-      # Separate compilation from testing to accurately report the runtime of each
-
-      # DISCUSS: is it possible to simplify the complexity here? Maybe we can assume the
-      # dependencies need to be installed to run tests, even if `cargo test` isn't how the tests are invoked.
-      # Consider that change for a future release.
-      - if: startsWith(inputs.test-command, 'cargo test')
-        run: cargo test --no-run ${{ contains(inputs.test-command, '--locked') && '--locked' || '' }}
-
-      - run: ${{ inputs.test-command }}
-
-      ###
-      # Phase 3: compile release binary
+      # Phase 2: compile release binary
 
       - name: Compile release binary
         env:
@@ -259,7 +321,7 @@ jobs:
             --target ${{ matrix.build.target }}
 
       ###
-      # Phase 4: configure release artifacts
+      # Phase 3: configure release artifacts
 
       - name: Install semantic-release-cargo
         uses: EricCrosson/install-github-release-binary@v2
@@ -306,7 +368,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - get-next-version
-      - configure-compilation-matrix
+      - configure-job-matrix
+      - test
       - build-release
 
     steps:
@@ -314,7 +377,7 @@ jobs:
         uses: semantic-release-action/rust/semantic-release-binary@beta
         with:
           toolchain: ${{ inputs.toolchain }}
-          compiled-targets: ${{ needs.configure-compilation-matrix.outputs.matrix }}
+          compiled-targets: ${{ needs.configure-job-matrix.outputs.compilation-matrix }}
           cargo-registry-token: ${{ secrets.cargo-registry-token }}
           disable-semantic-release-cargo: ${{ inputs.disable-semantic-release-cargo }}
           disable-semantic-release-git: ${{ inputs.disable-semantic-release-git }}

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -136,7 +136,7 @@ jobs:
               --argjson targets_whitelist "$targets_whitelist" \
               --argjson target_triples "$target_triples" \
               --argjson binary_names "$binary_names" \
-              '($target_triples[] | select(.target | IN($targets_whitelist))) + $binary_names[]'
+              '($target_triples[] | select(.target | IN($targets_whitelist[]))) + $binary_names[]'
           )"
           {
             echo "matrix<<EOF"

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -247,16 +247,20 @@ jobs:
 
       # Separate compilation from testing to accurately report the runtime of each
 
-      - run: |
+      - env:
+          CARGO: ${{ matrix.test.cross && 'cross' || 'cargo' }}
+        run: |
           : build tests
-          cargo test \
+          $CARGO test \
             --target ${{ matrix.test.target }} \
             --no-run \
             --locked
 
-      - run: |
+      - env:
+          CARGO: ${{ matrix.test.cross && 'cross' || 'cargo' }}
+        run: |
           : tests
-          cargo test \
+          $CARGO test \
             --target ${{ matrix.test.target }} \
             --locked \
             -- \

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -136,7 +136,7 @@ jobs:
               --argjson targets_whitelist "$targets_whitelist" \
               --argjson target_triples "$target_triples" \
               --argjson binary_names "$binary_names" \
-              '($target_triples[] | select(.target | IN($targets_whitelist))) + $binary_name[]'
+              '($target_triples[] | select(.target | IN($targets_whitelist))) + $binary_names[]'
           )"
           {
             echo "matrix<<EOF"

--- a/.github/workflows/release-library.yml
+++ b/.github/workflows/release-library.yml
@@ -9,10 +9,6 @@ on:
         required: false
         type: string
         default: false
-      test-command:
-        description: Command used to test your Rust program
-        type: string
-        default: cargo test -- --nocapture
       toolchain:
         description: Rust toolchain specification
         type: string
@@ -47,7 +43,6 @@ jobs:
         uses: semantic-release-action/rust/semantic-release-library@v4
         with:
           toolchain: ${{ inputs.toolchain }}
-          test-command: ${{ inputs.test-command }}
           disable-semantic-release-cargo: ${{ inputs.disable-semantic-release-cargo }}
           disable-semantic-release-git: ${{ inputs.disable-semantic-release-git }}
           cargo-registry-token: ${{ secrets.cargo-registry-token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [4.5.0-beta.3](https://github.com/semantic-release-action/rust/compare/v4.5.0-beta.2...v4.5.0-beta.3) (2023-09-16)
+
+
+### Bug Fixes
+
+* add checkout ([e1fbdce](https://github.com/semantic-release-action/rust/commit/e1fbdce1ab115773f3ccff614ad46bc9860b8f85))
+
 # [4.5.0-beta.2](https://github.com/semantic-release-action/rust/compare/v4.5.0-beta.1...v4.5.0-beta.2) (2023-09-16)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [4.5.0-beta.2](https://github.com/semantic-release-action/rust/compare/v4.5.0-beta.1...v4.5.0-beta.2) (2023-09-16)
+
+
+### Bug Fixes
+
+* fix shell syntax ([ab93f39](https://github.com/semantic-release-action/rust/commit/ab93f39b95543e44b2d89df1fd138c87d5ed287c))
+
 # [4.5.0-beta.1](https://github.com/semantic-release-action/rust/compare/v4.4.46...v4.5.0-beta.1) (2023-09-16)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [5.0.0-beta.3](https://github.com/semantic-release-action/rust/compare/v5.0.0-beta.2...v5.0.0-beta.3) (2023-09-17)
+
+
+### Bug Fixes
+
+* do not run aarch64-apple-darwin tests with cross ([b5a6706](https://github.com/semantic-release-action/rust/commit/b5a67061766d754e65216ef6623bd593e61023b0))
+
 # [5.0.0-beta.2](https://github.com/semantic-release-action/rust/compare/v5.0.0-beta.1...v5.0.0-beta.2) (2023-09-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [4.5.0-beta.1](https://github.com/semantic-release-action/rust/compare/v4.4.46...v4.5.0-beta.1) (2023-09-16)
+
+
+### Features
+
+* support multiple binaries ([841cc68](https://github.com/semantic-release-action/rust/commit/841cc686a56005005e8f5b7505ac6b42048f231c)), closes [#13](https://github.com/semantic-release-action/rust/issues/13) [#31](https://github.com/semantic-release-action/rust/issues/31)
+
 ## [4.4.46](https://github.com/semantic-release-action/rust/compare/v4.4.45...v4.4.46) (2023-09-16)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [5.0.0-beta.1](https://github.com/semantic-release-action/rust/compare/v4.5.0-beta.3...v5.0.0-beta.1) (2023-09-17)
+
+
+* chore!: drop support for specifying `test-command` ([11d9061](https://github.com/semantic-release-action/rust/commit/11d906168e271496ca26d22521f74c70e79bb2b5))
+
+
+### BREAKING CHANGES
+
+* drop support for specifying `test-command`
+
 # [4.5.0-beta.3](https://github.com/semantic-release-action/rust/compare/v4.5.0-beta.2...v4.5.0-beta.3) (2023-09-16)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [5.0.0-beta.2](https://github.com/semantic-release-action/rust/compare/v5.0.0-beta.1...v5.0.0-beta.2) (2023-09-17)
+
+
+### Bug Fixes
+
+* use cross to run tests when necessary ([49cdcbe](https://github.com/semantic-release-action/rust/commit/49cdcbe0a3564f89d27ccc4c8c020820f27a31a7))
+
 # [5.0.0-beta.1](https://github.com/semantic-release-action/rust/compare/v4.5.0-beta.3...v5.0.0-beta.1) (2023-09-17)
 
 

--- a/README.md
+++ b/README.md
@@ -38,22 +38,16 @@ jobs:
 
 ### Inputs
 
-| Input Parameter |               Default                | Description                                                                            |
-| :-------------: | :----------------------------------: | -------------------------------------------------------------------------------------- |
-|  test-command   | `cargo test --locked -- --nocapture` | Shell command used to provide confidence in proposed changes. [Details](#test-command) |
-|    toolchain    |               `stable`               | Rust toolchain specification. [Details](#toolchain)                                    |
-|   submodules    |               `false`                | Whether to checkout submodules. [Details](#submodules)                                 |
+| Input Parameter | Default  | Description                                            |
+| :-------------: | :------: | ------------------------------------------------------ |
+|    toolchain    | `stable` | Rust toolchain specification. [Details](#toolchain)    |
+|   submodules    | `false`  | Whether to checkout submodules. [Details](#submodules) |
 
 #### toolchain
 
 Specify a Rust [toolchain].
 
 [toolchain]: https://rust-lang.github.io/rustup/concepts/toolchains.html#toolchain-specification
-
-#### test-command
-
-The shell command used to provide confidence in the proposed changes.
-Defaults to `cargo test --locked -- --nocapture` for binaries and `cargo test -- --nocapture` for libraries, but you can override this to `cargo check` or anything else.
 
 #### submodules
 
@@ -110,14 +104,13 @@ jobs:
 
 ### Inputs
 
-|        Input Parameter         |               Default                | Description                                                                                       |
-| :----------------------------: | :----------------------------------: | ------------------------------------------------------------------------------------------------- |
-|            targets             |            all supported             | Whitelist of compilation targets to upload GitHub release binaries for. [Details](#targets)       |
-|          test-command          | `cargo test --locked -- --nocapture` | Shell command used to provide confidence in proposed changes. [Details](#test-command)            |
-|           toolchain            |               `stable`               | Rust toolchain specification. [Details](#toolchain)                                               |
-| disable-semantic-release-cargo |               `false`                | Disable [semantic-release-cargo] in your release flow. [Details](#disable-semantic-release-cargo) |
-|  disable-semantic-release-git  |               `false`                | Disable [@semantic-release/git] in your release flow. [Details](#disable-semantic-release-git)    |
-|           submodules           |               `false`                | Whether to checkout submodules. [Details](#submodules)                                            |
+|        Input Parameter         |    Default    | Description                                                                                       |
+| :----------------------------: | :-----------: | ------------------------------------------------------------------------------------------------- |
+|            targets             | all supported | Whitelist of compilation targets to upload GitHub release binaries for. [Details](#targets)       |
+|           toolchain            |   `stable`    | Rust toolchain specification. [Details](#toolchain)                                               |
+| disable-semantic-release-cargo |    `false`    | Disable [semantic-release-cargo] in your release flow. [Details](#disable-semantic-release-cargo) |
+|  disable-semantic-release-git  |    `false`    | Disable [@semantic-release/git] in your release flow. [Details](#disable-semantic-release-git)    |
+|           submodules           |    `false`    | Whether to checkout submodules. [Details](#submodules)                                            |
 
 #### targets
 
@@ -212,13 +205,12 @@ jobs:
 
 ### Inputs
 
-|        Input Parameter         |           Default           | Description                                                                                       |
-| :----------------------------: | :-------------------------: | ------------------------------------------------------------------------------------------------- |
-|           toolchain            |          `stable`           | Rust toolchain specification. [Details](#toolchain)                                               |
-|          test-command          | `cargo test -- --nocapture` | Shell command used to provide confidence in proposed changes. [Details](#test-command)            |
-| disable-semantic-release-cargo |           `false`           | Disable [semantic-release-cargo] in your release flow. [Details](#disable-semantic-release-cargo) |
-|  disable-semantic-release-git  |           `false`           | Disable [@semantic-release/git] in your release flow. [Details](#disable-semantic-release-git)    |
-|           submodules           |           `false`           | Whether to checkout submodules. [Details](#submodules)                                            |
+|        Input Parameter         | Default  | Description                                                                                       |
+| :----------------------------: | :------: | ------------------------------------------------------------------------------------------------- |
+|           toolchain            | `stable` | Rust toolchain specification. [Details](#toolchain)                                               |
+| disable-semantic-release-cargo | `false`  | Disable [semantic-release-cargo] in your release flow. [Details](#disable-semantic-release-cargo) |
+|  disable-semantic-release-git  | `false`  | Disable [@semantic-release/git] in your release flow. [Details](#disable-semantic-release-git)    |
+|           submodules           | `false`  | Whether to checkout submodules. [Details](#submodules)                                            |
 
 ### Secrets
 

--- a/README.md
+++ b/README.md
@@ -84,13 +84,6 @@ Each deploy:
 
 [cargo binstall]: https://github.com/cargo-bins/cargo-binstall
 
-### Limitations
-
-This workflow currently only supports releasing a single binary.
-To release library crates, use the [release-library workflow].
-
-[release-library workflow]: #release-library
-
 ### Use
 
 ```yaml

--- a/semantic-release-binary/.releaserc.json
+++ b/semantic-release-binary/.releaserc.json
@@ -15,38 +15,6 @@
       {
         "assets": [
           {
-            "path": ".semantic-release-action_rust/dist/x86_64-unknown-linux-musl/BINARY_NAME-x86_64-unknown-linux-musl",
-            "label": "x86_64-unknown-linux-musl"
-          },
-          {
-            "path": ".semantic-release-action_rust/dist/x86_64-unknown-linux-gnu/BINARY_NAME-x86_64-unknown-linux-gnu",
-            "label": "x86_64-unknown-linux-gnu"
-          },
-          {
-            "path": ".semantic-release-action_rust/dist/i686-unknown-linux-musl/BINARY_NAME-i686-unknown-linux-musl",
-            "label": "i686-unknown-linux-musl"
-          },
-          {
-            "path": ".semantic-release-action_rust/dist/i686-unknown-linux-gnu/BINARY_NAME-i686-unknown-linux-gnu",
-            "label": "i686-unknown-linux-gnu"
-          },
-          {
-            "path": ".semantic-release-action_rust/dist/x86_64-apple-darwin/BINARY_NAME-x86_64-apple-darwin",
-            "label": "x86_64-apple-darwin"
-          },
-          {
-            "path": ".semantic-release-action_rust/dist/aarch64-unknown-linux-musl/BINARY_NAME-aarch64-unknown-linux-musl",
-            "label": "aarch64-unknown-linux-musl"
-          },
-          {
-            "path": ".semantic-release-action_rust/dist/aarch64-unknown-linux-gnu/BINARY_NAME-aarch64-unknown-linux-gnu",
-            "label": "aarch64-unknown-linux-gnu"
-          },
-          {
-            "path": ".semantic-release-action_rust/dist/aarch64-apple-darwin/BINARY_NAME-aarch64-apple-darwin",
-            "label": "aarch64-apple-darwin"
-          },
-          {
             "path": ".semantic-release-action_rust/dist/SHA256SUMS.txt",
             "label": "SHA256SUMS.txt"
           }

--- a/semantic-release-binary/action.yml
+++ b/semantic-release-binary/action.yml
@@ -142,6 +142,7 @@ runs:
     #    This permits specifying which binary to install with
     #    EricCrosson/install-github-release-binary.
     #
+    # TODO: simplify this when install-github-release-binary is updated; always use the second approach.
     - if: steps.is-semantic-release-configured.outputs.host-configuration == 'false'
       id: enumerate-binary-release-assets
       env:

--- a/semantic-release-binary/action.yml
+++ b/semantic-release-binary/action.yml
@@ -17,8 +17,19 @@ inputs:
     description: Rust toolchain specification
     required: false
     default: stable
-  binary-name:
-    description: The name of your Rust binary
+  compiled-targets:
+    description: |
+      Stringified JSON array describing each precompiled release artifact.
+
+      Example:
+      ```json
+      [
+        { "binary_name": "foo", "target": "x86_64-unknown-linux-musl" },
+        { "binary_name": "bar", "target": "x86_64-unknown-linux-musl" },
+        { "binary_name": "foo", "target": "aarch64-apple-darwin" },
+        { "binary_name": "bar", "target": "aarch64-apple-darwin" }
+      ]
+      ```
     required: true
   cargo-registry-token:
     description: API token for writing to your cargo registry
@@ -41,7 +52,8 @@ runs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        # Fetch all history and tags for calculating next semantic version
+        # Fetch all history and tags so semantic-release can calculate the next release version.
+        # (Even though _we_ have alerady calculated the next version, semantic-release will do it again.)
         fetch-depth: 0
         submodules: ${{ inputs.submodules }}
 
@@ -104,13 +116,89 @@ runs:
         echo "/.semantic-release-action_rust/" >> "$HOME/.config/git/ignore"
       shell: bash
 
+    # This action supports two modes for uploading assets to a GitHub release:
+    #
+    # 1. single binary assets (this was the original implementation)
+    #
+    #    When there is only one binary to upload, use the format:
+    #
+    #    ```json
+    #    {
+    #      "path": <path>,
+    #      "label": <target-triple>
+    #    }
+    #    ```
+    #
+    #    This makes installing the binary with EricCrosson/install-github-
+    #    release-binary as straightfoward as possible.
+    #
+    # 2. multiple binary assets
+    #
+    #    When there is only one binary to upload, use the format:
+    #
+    #    ```json
+    #    {
+    #      "path": <path>,
+    #      "label": <binary-name>-<target-triple>
+    #    }
+    #    ```
+    #
+    #    This permits specifying which binary to install with
+    #    EricCrosson/install-github-release-binary.
+    #
     - if: steps.is-semantic-release-configured.outputs.host-configuration == 'false'
+      id: enumerate-binary-release-assets
+      env:
+        compiled_targets: ${{ inputs.compiled-targets }}
+      run: |
+        : enumerate binary release assets
+
+        are_releasing_multiple_binaries="$(
+          jq 'unique_by(.binary_name) | length > 1' <<< "$compiled_targets"
+        )"
+
+        release_assets="$(jq \
+          --null-input \
+          --argjson are_releasing_multiple_binaries "$are_releasing_multiple_binaries" \ 
+          --argjson compiled_targets "$compiled_targets" \
+          '
+            $compiled_targets
+            | map({
+              path: ".semantic-release-action_rust/dist/\(.target)/\(.binary_name)-\(.target)",
+              label: "\(if $are_releasing_multiple_binaries then "\(.binary_name)-" else "" end)\(.target)" 
+            })
+          '
+        )"
+
+        # Array<{ path: string, label: string }>
+        {
+          echo "release-assets<<EOF"
+          echo "$release_assets"
+          echo "EOF"
+        } >> "$GITHUB_ACTIONS"
+      shell: bash
+
+    - if: steps.is-semantic-release-configured.outputs.host-configuration == 'false'
+      env:
+        release_assets: ${{ steps.enumerate-binary-release-assets.outputs.release-assets }}
       run: |
         : install semantic-release manifest
         cp "${{ github.action_path }}/package.json" "${{ env.node_workdir }}/package.json"
         cp "${{ github.action_path }}/package-lock.json" "${{ env.node_workdir }}/package-lock.json"
-        cp ${{ github.action_path }}/.releaserc.json .releaserc.json
-        sed -i 's/BINARY_NAME/${{ inputs.binary-name }}/g' .releaserc.json
+
+        jq \
+          --argjson release_assets "$release_assets" \
+          '
+            .plugins |= map(
+              if type == "array" and .[0] == "@semantic-release/github" then
+                .[1].assets += $release_assets
+              else
+                .
+              end
+            )
+          ' \
+          ${{ github.action_path }}/.releaserc.json \
+          > .releaserc.json
       shell: bash
 
     - if: steps.is-semantic-release-configured.outputs.host-configuration == 'false' && inputs.disable-semantic-release-cargo == 'true'
@@ -139,32 +227,8 @@ runs:
         mv "${tmpdir}/.releaserc.json" .releaserc.json
       shell: bash
 
-    - env:
-        selected_targets: ${{ inputs.targets }}
-        tmpdir: ${{ runner.temp }}
-      run: |
-        : configure semantic-release assets
-        whitelist="$(
-          echo "$selected_targets SHAS256SUMS.txt" \
-          | jq --null-input --raw-input '[inputs] | map(split("\\s"; null)[] | select(length > 0))'
-        )"
-
-        jq \
-          --argjson whitelist "$whitelist" \
-          '
-            .plugins |= (
-              map(select(type == "array" and .[0] == "@semantic-release/github")[1].assets |=
-                map(select(.label | IN($whitelist[]))))
-            )
-          ' \
-          .releaserc.json \
-        > "${tmpdir}/.releaserc.json"
-
-        mv "${tmpdir}/.releaserc.json" .releaserc.json
-      shell: bash
-
-    # If the semantic-release-cargo plugin never runs, the cargo manifest never has its version bumped.
-    # Run the prepare step of semantic-release-cargo by invoking its binary directly.
+    # When the semantic-release-cargo plugin is disabled, the cargo manifest never has its version bumped.
+    # Run the semantic-release-cargo's prepare step the binary directly.
     - name: Install semantic-release-cargo
       if: steps.is-semantic-release-configured.outputs.host-configuration == 'false' && inputs.disable-semantic-release-cargo == 'true'
       uses: EricCrosson/install-github-release-binary@v2
@@ -184,7 +248,7 @@ runs:
 
     - run: |
         : combine checksums
-        cat **/${{ inputs.binary-name }}-*-SHA256SUM.txt | tee SHA256SUMS.txt
+        cat **/*-SHA256SUM.txt | tee SHA256SUMS.txt
       working-directory: ${{ env.artifact_dir }}
       shell: bash
 

--- a/semantic-release-binary/action.yml
+++ b/semantic-release-binary/action.yml
@@ -10,13 +10,9 @@ branding:
 # (which is only supported in composite actions)
 
 inputs:
-  targets:
-    description: Whitelist of compilation targets to upload GitHub release binaries for. Must be a subset of supported targets.
-    required: true
   toolchain:
     description: Rust toolchain specification
-    required: false
-    default: stable
+    required: true
   compiled-targets:
     description: |
       Stringified JSON array describing each precompiled release artifact.

--- a/semantic-release-binary/action.yml
+++ b/semantic-release-binary/action.yml
@@ -247,6 +247,12 @@ runs:
         path: ${{ env.artifact_dir }}
 
     - run: |
+        : display downloaded release artifacts
+        ls -R
+      working-directory: ${{ env.artifact_dir }}
+      shell: bash
+
+    - run: |
         : combine checksums
         cat **/*-SHA256SUM.txt | tee SHA256SUMS.txt
       working-directory: ${{ env.artifact_dir }}

--- a/semantic-release-binary/action.yml
+++ b/semantic-release-binary/action.yml
@@ -244,6 +244,7 @@ runs:
       with:
         path: ${{ env.artifact_dir }}
 
+    # TODO: gate this behind the debug flag
     - run: |
         : display downloaded release artifacts
         ls -R

--- a/semantic-release-binary/action.yml
+++ b/semantic-release-binary/action.yml
@@ -172,7 +172,7 @@ runs:
           echo "release-assets<<EOF"
           echo "$release_assets"
           echo "EOF"
-        } >> "$GITHUB_ACTIONS"
+        } >> "$GITHUB_OUTPUT"
       shell: bash
 
     - if: steps.is-semantic-release-configured.outputs.host-configuration == 'false'

--- a/semantic-release-binary/action.yml
+++ b/semantic-release-binary/action.yml
@@ -153,17 +153,18 @@ runs:
           jq 'unique_by(.binary_name) | length > 1' <<< "$compiled_targets"
         )"
 
-        release_assets="$(jq \
-          --null-input \
-          --argjson are_releasing_multiple_binaries "$are_releasing_multiple_binaries" \ 
-          --argjson compiled_targets "$compiled_targets" \
-          '
-            $compiled_targets
-            | map({
-              path: ".semantic-release-action_rust/dist/\(.target)/\(.binary_name)-\(.target)",
-              label: "\(if $are_releasing_multiple_binaries then "\(.binary_name)-" else "" end)\(.target)" 
-            })
-          '
+        release_assets="$(
+          jq \
+            --null-input \
+            --argjson are_releasing_multiple_binaries "$are_releasing_multiple_binaries" \
+            --argjson compiled_targets "$compiled_targets" \
+            '
+              $compiled_targets
+              | map({
+                path: ".semantic-release-action_rust/dist/\(.target)/\(.binary_name)-\(.target)",
+                label: "\(if $are_releasing_multiple_binaries then "\(.binary_name)-" else "" end)\(.target)" 
+              })
+            '
         )"
 
         # Array<{ path: string, label: string }>

--- a/semantic-release-library/action.yml
+++ b/semantic-release-library/action.yml
@@ -14,10 +14,6 @@ inputs:
     description: Rust toolchain specification
     required: false
     default: stable
-  test-command:
-    description: Command used to test your Rust program
-    required: false
-    default: cargo test
   disable-semantic-release-cargo:
     description: Disable semantic-release-cargo in your release flow. Only takes effect if the action semantic-release config is used.
     default: false
@@ -49,11 +45,19 @@ runs:
       uses: Swatinem/rust-cache@v2
 
     # Separate compilation from testing to accurately report the runtime of each
-    - if: startsWith(inputs.test-command, 'cargo test')
-      run: cargo test --no-run
+    - run: |
+        : build tests
+        cargo test \
+          --target ${{ matrix.test.target }} \
+          --no-run
       shell: bash
 
-    - run: ${{ inputs.test-command }}
+    - run: |
+        : tests
+        cargo test \
+          --target ${{ matrix.test.target }} \
+          -- \
+          --nocapture
       shell: bash
 
     - name: Install is-semantic-release-configured


### PR DESCRIPTION
Features:

- support releasing multiple binaries

   When your project creates multiple binaries, this action will release all of them for the targeted architectures. When multiple binaries are released, the release asset label changes: when one binary is released, the label is that binary's target triple; when multiple binaries are released, the label format is `<binary-name>-<target-triple>`. This format is supported by `install-github-release-binary` as of [v2.3.0](https://github.com/EricCrosson/install-github-release-binary/releases/tag/v2.3.0).

   I have tested this feature with cargo workspaces, though not with a single-crate project. I don't expect a single-crate project to behave any differently.

Breaking changes:

- drop support for `test-command`