### PR TITLE
feat: add crates.io trusted publishing support via OIDC

### DIFF
--- a/semantic-release-binary/action.yml
+++ b/semantic-release-binary/action.yml
@@ -271,12 +271,17 @@ runs:
       working-directory: ${{ env.node_workdir }}
       shell: bash
 
+    - name: Authenticate with crates.io (Trusted Publishing)
+      if: inputs.cargo-registry-token == ''
+      id: crates-io-auth
+      uses: rust-lang/crates-io-auth-action@v1
+
     - run: |
         : semantic-release
         ${semantic_release}
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
-        CARGO_REGISTRY_TOKEN: ${{ inputs.cargo-registry-token }}
+        CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token || inputs.cargo-registry-token }}
       shell: bash
 
     - run: |

--- a/semantic-release-library/action.yml
+++ b/semantic-release-library/action.yml
@@ -179,10 +179,15 @@ runs:
       working-directory: ${{ env.node_workdir }}
       shell: bash
 
+    - name: Authenticate with crates.io (Trusted Publishing)
+      if: inputs.cargo-registry-token == ''
+      id: crates-io-auth
+      uses: rust-lang/crates-io-auth-action@v1
+
     - run: |
         : semantic-release
         ${semantic_release}
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
-        CARGO_REGISTRY_TOKEN: ${{ inputs.cargo-registry-token }}
+        CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token || inputs.cargo-registry-token }}
       shell: bash


### PR DESCRIPTION
## Summary

- Adds optional OIDC-based [trusted publishing](https://doc.rust-lang.org/cargo/reference/registry-authentication.html#trusted-publishing) support to both composite actions
- When no `cargo-registry-token` is provided, uses [`rust-lang/crates-io-auth-action@v1`](https://github.com/rust-lang/crates-io-auth-action) to obtain a short-lived OIDC token from crates.io
- Fully backwards-compatible: existing users who pass a `cargo-registry-token` are completely unaffected (the OIDC step is skipped via `if` condition)

## How it works

In both `semantic-release-binary/action.yml` and `semantic-release-library/action.yml`, a new conditional step is added before the semantic-release step:

```yaml
- name: Authenticate with crates.io (Trusted Publishing)
  if: inputs.cargo-registry-token == ''
  id: crates-io-auth
  uses: rust-lang/crates-io-auth-action@v1

- run: |
    : semantic-release
    ${semantic_release}
  env:
    GITHUB_TOKEN: ${{ inputs.github_token }}
    CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token || inputs.cargo-registry-token }}
```

- If `cargo-registry-token` is provided: OIDC step is skipped, token falls through to `inputs.cargo-registry-token`
- If `cargo-registry-token` is empty: OIDC step runs, obtains a short-lived token, that token is used

Callers need `id-token: write` permission and must configure their crates on crates.io with a [trusted publisher](https://crates.io/docs/trusted-publishing).

## Verified

This has been tested in production on [starfy84/git-seek](https://github.com/starfy84/git-seek) using a fork of this action, successfully publishing two crates via trusted publishing:
- https://github.com/starfy84/git-seek/actions/runs/22267240586